### PR TITLE
Update error-reference.md for error 7003

### DIFF
--- a/website/docs/error-reference.md
+++ b/website/docs/error-reference.md
@@ -2811,11 +2811,22 @@ This error indicates a call to a method we believe does not exist (a la Ruby's
     `Object` (which classes default to inheriting from), but not on
     `BasicObject` (which classes can optionally inherit from).
 
-    The solution is to `include Kernel` in our module:
+    One solution is to `include Kernel` in our module:
 
     ```ruby
     module MyModule
       include Kernel
+    end
+    ```
+    
+    An alternative solution is to use the expirimental `requires_ancestor` from
+    `T::Helpers` to ensure `Kernel` is an ancestor of the class being mixed
+    into at runtime.
+    
+    ```ruby
+    module MyModule
+      include T::Helpers
+      requires_ancestor Kernel
     end
     ```
 


### PR DESCRIPTION
<!-- (optional) Explain your change, focusing on the details of the solution. This is a great place to call out user-visible changes. -->
Provide an alternative solution to error 7003. Since what we ultimately want to do is provide a guarantee that `Kernel#raise` exists on the class being mixed into at runtime, `requires_ancestor` is a viable alternative.

### Motivation
<!-- Why make this change? Describe the problem, not the solution. This can also be a link to an issue. -->
I think providing both solutions gives the user choice. This would also help provide some visibility into this expirimental feature and help drive testing it.

### Test plan
<!-- If you did not write tests for this change, replace the message below explaining why not. Why we should be confident this change is correct? If you changed the website, please include a screenshot of the proposed changes. -->

This is a documentation change, test changes are required.
